### PR TITLE
Update link to Slack and adding 'Mentors' role

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
    * [Responsibilities](#Responsibilities-1)
 * [Homepage/Social Media People](#homepagesocial-media-people)
    * [Responsibilities](#responsibilities-1)
-
+* [Mentors](#mentors)
 
 # "Roles"
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
+* [Project "Leads"](#project-leads)
+   * [Responsibilities](#responsibilities)
+* [Representative(s)](#representatives)
+   * [Responsibilities](#Responsibilities)
+* [Moderator(s)](#moderators)
+   * [Responsibilities](#Responsibilities-1)
+* [Homepage/Social Media People](#homepagesocial-media-people)
+   * [Responsibilities](#responsibilities-1)
+
+
 # "Roles"
 
-We have defined a few "roles" that are supposed to solve a few common tasks, thereby empowering our community to focus on actual development work and problem solving. If you feel, that something is missing, create an issue within this repo or post in our [#organization channel in Slack](https://data4good-no.slack.com/messages/C9MUKBM7D)
+We have defined a few "roles" that are supposed to solve a few common tasks, thereby empowering our community to focus on actual development work and problem solving. If you feel, that something is missing, create an issue within this repo or post in our [#organization channel in Slack](https://dataforgood-norway.slack.com/messages/C9RRH3D1T/)
 
 ## Project "Leads"
 
-Each project we do needs a scrum-style go-to-person. It is what, e.g., Data for Democracy are doing.
+Each project we do needs a scrum-style go-to-person. It is what, e.g., Data for Democracy is doing.
 This role changes from project to project and will be at the core
 of DfG.
 
@@ -12,7 +22,7 @@ of DfG.
 
  - keep the group on track
  - take questions
- - help new folks joining a project get settled in 
+ - help new folks joining a project get settled in
 
 ## Representative(s)
 
@@ -26,14 +36,14 @@ funding are involved, a
 representative will certainly be
 useful. For obvious reasons, *native Norwegian speakers* would be a suitable choice.
 
-### Reponsibilities
+### Responsibilities
 - being the contact person for
 people/organizations who
 want to get in touch with DfG
 - advertise what we do face-to-face
 -...
 
-## Moderator(s) 
+## Meeting Moderator(s)
 
 In meetings, it is important that
 communication is efficient in
@@ -45,7 +55,7 @@ subjects/problems are discussed
 people) is determined to
 implement/do stuff
 
-### Reponsibilities
+### Responsibilities
 
 - organize time and location of
 meetings
@@ -59,7 +69,8 @@ who were not at the meeting
 are still up to date with regards
 to important things
 
-## Homepage/Social Media People
+
+## Homepage/Social Media team
 
 Ensure that we have a coherent and up to
 date online representation of
@@ -75,3 +86,11 @@ create (maybe this could also
 be delegated to the people who
 mainly work on these projects)
 - ...
+
+
+
+## Mentors
+
+Given the various domain of expertise we might need on a project, it might often be useful for a team to reach out to an expert on a specific issue.
+Working with a mentor can be an invaluable experience for both parties. The mentor and mentee will likely learn new things about themselves and each other.
+We will find a way to build this list of experts who voluntarily use their skills to help other's projects from time to time.


### PR DESCRIPTION
When writing the minutes of meeting and as part of the suggestion, I am adding the role of mentors.  This is incomplete as I couldn't find proper way to formulate their responsibilities. And we also need to find how we can make some kind of "trombinoscope" where members can sell some skills/expertise.